### PR TITLE
ENH: Log construction and solve time for iterative solver

### DIFF
--- a/src/pp_solvers/solver_mixin.py
+++ b/src/pp_solvers/solver_mixin.py
@@ -32,6 +32,11 @@ from pp_solvers.preconditioners import (
     th_factory,
     thm_factory,
 )
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
 
 from .block_linear_system import BlockLinearSystem, LinearSystemIndexer
 
@@ -162,6 +167,7 @@ class IterativeSolverMixin(pp.PorePyModel):
             ) from e
 
         self.linear_solver_statistics.linsolve_construction_time.append(time() - t0)
+        logger.info("Linear solver constructed in %.2f seconds.", time() - t0)
 
         # Project the right hand side to the local block matrix ordering, as was done
         # for the block matrix during assembly. We need to do this on the reordered rhs
@@ -169,6 +175,12 @@ class IterativeSolverMixin(pp.PorePyModel):
         t0 = time()
         x_loc = solver.solve(rhs)
         self.linear_solver_statistics.linsolve_solve_time.append(time() - t0)
+        num_it = len(solver.get_residuals())
+        logger.info(
+            "Linear system solved in %.2f seconds with %d iterations.",
+            time() - t0,
+            num_it,
+        )
 
         info = solver.ksp.getConvergedReason()
         if info <= 0:
@@ -182,9 +194,7 @@ class IterativeSolverMixin(pp.PorePyModel):
         # (columns) were reordered.
         x = self.bmat.permute_right_vector_to_original(x_loc)
         self.linear_solver_statistics.petsc_converged_reason.append(info)
-        self.linear_solver_statistics.num_krylov_iters.append(
-            len(solver.get_residuals())
-        )
+        self.linear_solver_statistics.num_krylov_iters.append(num_it)
 
         return np.atleast_1d(x)
 

--- a/src/pp_solvers/solver_mixin.py
+++ b/src/pp_solvers/solver_mixin.py
@@ -228,6 +228,13 @@ class IterativeSolverMixin(pp.PorePyModel):
     def _initialize_linear_solver(self):
         # Set up preconditioner.
 
+        # Add fields for the linear solver statistics to the nonlinear solver statistics
+        # object.
+        self.nonlinear_solver_statistics.linsolve_construction_time = []
+        self.nonlinear_solver_statistics.linsolve_solve_time = []
+        self.nonlinear_solver_statistics.petsc_converged_reason = []
+        self.nonlinear_solver_statistics.num_krylov_iters = []
+
         precond_factory: Callable[[], PetscKspPcConfiguration]
         linear_solver_params = self.params.get("linear_solver", {})
         precond_factory = linear_solver_params.get("preconditioner_factory", None)

--- a/src/pp_solvers/solver_mixin.py
+++ b/src/pp_solvers/solver_mixin.py
@@ -35,7 +35,7 @@ from pp_solvers.preconditioners import (
 import logging
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logger.addHandler(logging.NullHandler())
 
 
 from .block_linear_system import BlockLinearSystem, LinearSystemIndexer
@@ -166,8 +166,9 @@ class IterativeSolverMixin(pp.PorePyModel):
                 "Failed to create solver with the provided preconditioner."
             ) from e
 
-        self.linear_solver_statistics.linsolve_construction_time.append(time() - t0)
-        logger.info("Linear solver constructed in %.2f seconds.", time() - t0)
+        elapsed = time() - t0
+        self.linear_solver_statistics.linsolve_construction_time.append(elapsed)
+        logger.info("Linear solver constructed in %.2f seconds.", elapsed)
 
         # Project the right hand side to the local block matrix ordering, as was done
         # for the block matrix during assembly. We need to do this on the reordered rhs


### PR DESCRIPTION
The logging approach is parallel to that used for direct solvers in the main PorePy repository.