### PR TITLE
MAINT: Fixed fieldsplit prefix

### DIFF
--- a/src/pp_solvers/preconditioners.py
+++ b/src/pp_solvers/preconditioners.py
@@ -527,6 +527,11 @@ class FieldSplitSchur(PetscKspPcConfiguration):
     ```
     with the Schur complement `S = D - B * A^-1 * C`.
 
+    **Note**: `petsc_tag` and `petsc_complement_tag` must be short, as PETSc has a limit
+    of 127 symbols for a prefix. They may not be equal to the `key` parameter: the tags
+    are for internal identification by PETSc, the key is for identification by
+    simulation developers.
+
     Parameters:
         subsolver: A configuration class of a solver that approximates `A^-1`.
         complement_solver: A configuration class of a solver that approximates `S^-1`.
@@ -550,11 +555,13 @@ class FieldSplitSchur(PetscKspPcConfiguration):
         key: str = "fieldsplit",
     ) -> None:
         # petsc_tag - internal, for petsc prefix. Must be short, not necessarily unique.
-        if petsc_complement_tag is None and petsc_tag is None:
+        if petsc_complement_tag is None:
+            if petsc_tag is not None:
+                petsc_complement_tag = f"{petsc_tag}_cpl"
+            else:
+                petsc_complement_tag = "keep"
+        if petsc_tag is None:
             petsc_tag = "elim"
-            petsc_complement_tag = "elim"
-        elif petsc_complement_tag is None:
-            petsc_complement_tag = f"{petsc_tag}_cpl"
         self.subsolver: PetscKspPcConfiguration = subsolver
         self.complement_solver: PetscKspPcConfiguration = complement_solver
         self.approximate_inverter: PetscInverter = approximate_inverter

--- a/tests/test_preconditioners.py
+++ b/tests/test_preconditioners.py
@@ -178,6 +178,7 @@ def test_composite_bad_groups():
         )
 
 
+@pytest.mark.filterwarnings("ignore:Both GMRES and preconditioner override options")
 @pytest.mark.parametrize(
     "configuration",
     CONFIGURATIONS_ALL,
@@ -201,6 +202,7 @@ def test_user_options_and_prefix(configuration: PetscKspPcConfiguration, prefix:
         assert petsc_options[f"{prefix}pc_type"] == "none"
 
 
+@pytest.mark.filterwarnings("ignore:Both GMRES and preconditioner override options")
 def test_gmres_and_preconditioner_override_user_params():
     configuration = GMRES(
         preconditioner=Identity(groups=["g1"], key="preconditioner"),
@@ -516,3 +518,66 @@ def test_petsc_ksp_scheme(block_linear_system: BlockLinearSystem):
         block_linear_system.mat @ solution,
         block_linear_system.rhs,
     )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        # Use all defaults: "elim" and "keep".
+        {
+            "petsc_tag": None,
+            "petsc_complement_tag": None,
+            "expected_petsc_options": {
+                "fieldsplit_elim_pc_type": "none",
+                "fieldsplit_keep_pc_type": "ilu",
+            },
+        },
+        # Use default for the complement: f"{petsc_tag}_cpl".
+        {
+            "petsc_tag": "custom_tag_1",
+            "petsc_complement_tag": None,
+            "expected_petsc_options": {
+                "fieldsplit_custom_tag_1_pc_type": "none",
+                "fieldsplit_custom_tag_1_cpl_pc_type": "ilu",
+            },
+        },
+        # Use default petsc_tag: "keep".
+        {
+            "petsc_tag": None,
+            "petsc_complement_tag": "custom_tag_2",
+            "expected_petsc_options": {
+                "fieldsplit_elim_pc_type": "none",
+                "fieldsplit_custom_tag_2_pc_type": "ilu",
+            },
+        },
+        # Custom values for both.
+        {
+            "petsc_tag": "custom_tag_1",
+            "petsc_complement_tag": "custom_tag_2",
+            "expected_petsc_options": {
+                "fieldsplit_custom_tag_1_pc_type": "none",
+                "fieldsplit_custom_tag_2_pc_type": "ilu",
+            },
+        },
+    ],
+)
+def test_fieldsplit_schur_default_parameters(params: dict):
+    """Tests non-trivial logic of creating FieldSplitSchur with default parameters
+    petsc_tag and petsc_complement_tag.
+
+    """
+    petsc_tag: str = params["petsc_tag"]
+    petsc_complement_tag: str = params["petsc_complement_tag"]
+    expected_petsc_options: dict = params["expected_petsc_options"]
+    preconditioner = FieldSplitSchur(
+        subsolver=Identity(groups=["mock_g1"]),
+        complement_solver=ILU(groups=["mock_g2"]),
+        approximate_inverter=DiagonalInverter(),
+        petsc_tag=petsc_tag,
+        petsc_complement_tag=petsc_complement_tag,
+    )
+    petsc_options = preconditioner.petsc_options(
+        user_options={}, prefix="", dof_manager=MockDofManager()
+    )
+    for key, value in expected_petsc_options.items():
+        assert petsc_options[key] == value


### PR DESCRIPTION
There was a mistake in #35 , fieldsplit default prefix was incorrect, and no unit test spotted it, because all used non-default parameters . I fixed it and added the corresponding test.