### PR TITLE
Delete global matrices that are not needed

### DIFF
--- a/src/pp_solvers/__init__.py
+++ b/src/pp_solvers/__init__.py
@@ -3,9 +3,9 @@ version = "0.0.1"
 from .block_linear_system import *
 from .mat_utils import *
 from .petsc_utils import *
+from .plot_linear_system import *
 from .preconditioners import *
 from .solver_mixin import *
-from .plot_linear_system import *
 
 __all__ = []
 __all__.extend(block_linear_system.__all__)

--- a/src/pp_solvers/block_linear_system.py
+++ b/src/pp_solvers/block_linear_system.py
@@ -368,6 +368,13 @@ class BlockLinearSystem:
         sliced_matrix = self.mat[rows_expanded, cols_expanded]
         rhs = self.rhs[groups_dofs_row]
 
+        if not sliced_matrix.data.flags.owndata:
+            # Slicing of a sparse matrix sometimes produces a view with considerable
+            # higher memory consumption than the original matrix. Copy the data to
+            # reclaim ownership and reduce memory consumption. We assume that the
+            # incurred overhead is minor compared to the benefits in saving memory.
+            sliced_matrix.data = sliced_matrix.data.copy()
+
         # Return a new block linear system object with the selected blocks. Compared to
         # the current object, the new object potentially has a subset of enabled groups,
         # with a corresponding subset of local indices (dofs_row and dofs_col).

--- a/src/pp_solvers/options_parsers.py
+++ b/src/pp_solvers/options_parsers.py
@@ -1,6 +1,7 @@
 """This module defines the machinery to parse the configuration of the PETSc linear
 solver and build the corresponding PETSc KSP and PC objects."""
 
+import gc
 from dataclasses import dataclass
 from typing import Optional
 from warnings import warn
@@ -8,19 +9,13 @@ from warnings import warn
 import numpy as np
 from petsc4py import PETSc
 
-from pp_solvers.block_linear_system import BlockLinearSystem, LinearSystemIndexer
+from pp_solvers.block_linear_system import (BlockLinearSystem,
+                                            LinearSystemIndexer)
 from pp_solvers.dof_manager import DofManager
-from pp_solvers.petsc_solvers import (
-    LinearSolverWithTransformations,
-    PcPythonPermutation,
-    PetscKrylovSolver,
-)
-from pp_solvers.petsc_utils import (
-    clear_petsc_options,
-    construct_is,
-    csr_to_petsc,
-    insert_petsc_options,
-)
+from pp_solvers.petsc_solvers import (LinearSolverWithTransformations,
+                                      PcPythonPermutation, PetscKrylovSolver)
+from pp_solvers.petsc_utils import (clear_petsc_options, construct_is,
+                                    csr_to_petsc, insert_petsc_options)
 from pp_solvers.preconditioners import PetscKspPcConfiguration
 
 
@@ -42,8 +37,9 @@ class PetscKSPScheme:
         # gather and count all the keys.
 
         # Construct a PETSc matrix from the scipy matrix.
-        # TODO EK: Can we at this point delete the scipy matrix to save memory?
         petsc_mat = csr_to_petsc(mat_orig.mat)
+        del mat_orig.mat  # Delete the scipy matrix to save memory.
+        gc.collect()
 
         # Clear the PETSc options from a previous solve.
         petsc_options = clear_petsc_options()

--- a/src/pp_solvers/options_parsers.py
+++ b/src/pp_solvers/options_parsers.py
@@ -9,13 +9,19 @@ from warnings import warn
 import numpy as np
 from petsc4py import PETSc
 
-from pp_solvers.block_linear_system import (BlockLinearSystem,
-                                            LinearSystemIndexer)
+from pp_solvers.block_linear_system import BlockLinearSystem, LinearSystemIndexer
 from pp_solvers.dof_manager import DofManager
-from pp_solvers.petsc_solvers import (LinearSolverWithTransformations,
-                                      PcPythonPermutation, PetscKrylovSolver)
-from pp_solvers.petsc_utils import (clear_petsc_options, construct_is,
-                                    csr_to_petsc, insert_petsc_options)
+from pp_solvers.petsc_solvers import (
+    LinearSolverWithTransformations,
+    PcPythonPermutation,
+    PetscKrylovSolver,
+)
+from pp_solvers.petsc_utils import (
+    clear_petsc_options,
+    construct_is,
+    csr_to_petsc,
+    insert_petsc_options,
+)
 from pp_solvers.preconditioners import PetscKspPcConfiguration
 
 

--- a/src/pp_solvers/options_parsers.py
+++ b/src/pp_solvers/options_parsers.py
@@ -1,7 +1,6 @@
 """This module defines the machinery to parse the configuration of the PETSc linear
 solver and build the corresponding PETSc KSP and PC objects."""
 
-import gc
 from dataclasses import dataclass
 from typing import Optional
 from warnings import warn
@@ -44,8 +43,8 @@ class PetscKSPScheme:
 
         # Construct a PETSc matrix from the scipy matrix.
         petsc_mat = csr_to_petsc(mat_orig.mat)
-        del mat_orig.mat  # Delete the scipy matrix to save memory.
-        gc.collect()
+        if options.get("delete_matrices", False):
+            del mat_orig.mat  # Delete the scipy matrix to save memory.
 
         # Clear the PETSc options from a previous solve.
         petsc_options = clear_petsc_options()

--- a/src/pp_solvers/solver_mixin.py
+++ b/src/pp_solvers/solver_mixin.py
@@ -5,7 +5,6 @@ of using iterative linear solvers to a PorePy model.
 
 from __future__ import annotations
 
-import gc
 import logging
 from dataclasses import dataclass, field
 from itertools import count
@@ -195,7 +194,8 @@ class IterativeSolverMixin(pp.PorePyModel):
         x = self.bmat.permute_right_vector_to_original(x_loc)
         self.linear_solver_statistics.petsc_converged_reason.append(info)
         self.linear_solver_statistics.num_krylov_iters.append(num_it)
-        del self.bmat
+        if self.params["linear_solver"].get("delete_matrices", True):
+            del self.bmat
 
         return np.atleast_1d(x)
 
@@ -224,8 +224,9 @@ class IterativeSolverMixin(pp.PorePyModel):
         # the blocks (and thereby the underlying matrix) to match the ordering defined
         # by the # `dof_manager`.
         self.bmat = bmat[:]
-        # Delete the original linear system to save memory.
-        del self.linear_system
+        # Delete the original linear system to save memory unless instructed not to.
+        if self.params["linear_solver"].get("delete_matrices", True):
+            del self.linear_system
 
     def _initialize_linear_solver(self):
         # Set up preconditioner.

--- a/src/pp_solvers/solver_mixin.py
+++ b/src/pp_solvers/solver_mixin.py
@@ -5,6 +5,8 @@ of using iterative linear solvers to a PorePy model.
 
 from __future__ import annotations
 
+import gc
+import logging
 from dataclasses import dataclass, field
 from itertools import count
 from time import time
@@ -32,7 +34,6 @@ from pp_solvers.preconditioners import (
     th_factory,
     thm_factory,
 )
-import logging
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -156,11 +157,9 @@ class IterativeSolverMixin(pp.PorePyModel):
             raise ValueError("RHS contains NaN or Inf values")
 
         solver_options = self.params["linear_solver"].get("options", {})
-        ksp_factory = self._solver_factory
-
         t0 = time()
         try:
-            solver = ksp_factory.make_solver(self.bmat, solver_options)
+            solver = self._solver_factory.make_solver(self.bmat, solver_options)
         except Exception as e:
             raise RuntimeError(
                 "Failed to create solver with the provided preconditioner."
@@ -196,6 +195,8 @@ class IterativeSolverMixin(pp.PorePyModel):
         x = self.bmat.permute_right_vector_to_original(x_loc)
         self.linear_solver_statistics.petsc_converged_reason.append(info)
         self.linear_solver_statistics.num_krylov_iters.append(num_it)
+        del self.bmat
+        gc.collect()
 
         return np.atleast_1d(x)
 
@@ -224,6 +225,9 @@ class IterativeSolverMixin(pp.PorePyModel):
         # the blocks (and thereby the underlying matrix) to match the ordering defined
         # by the # `dof_manager`.
         self.bmat = bmat[:]
+        # Delete the original linear system to save memory.
+        del self.linear_system
+        gc.collect()  # Force garbage collection to free memory immediately.
 
     def _initialize_linear_solver(self):
         # Set up preconditioner.

--- a/src/pp_solvers/solver_mixin.py
+++ b/src/pp_solvers/solver_mixin.py
@@ -196,7 +196,6 @@ class IterativeSolverMixin(pp.PorePyModel):
         self.linear_solver_statistics.petsc_converged_reason.append(info)
         self.linear_solver_statistics.num_krylov_iters.append(num_it)
         del self.bmat
-        gc.collect()
 
         return np.atleast_1d(x)
 
@@ -227,7 +226,6 @@ class IterativeSolverMixin(pp.PorePyModel):
         self.bmat = bmat[:]
         # Delete the original linear system to save memory.
         del self.linear_system
-        gc.collect()  # Force garbage collection to free memory immediately.
 
     def _initialize_linear_solver(self):
         # Set up preconditioner.

--- a/tests/test_preconditioners.py
+++ b/tests/test_preconditioners.py
@@ -508,7 +508,11 @@ def test_petsc_ksp_scheme(block_linear_system: BlockLinearSystem):
         dof_manager=MockDofManager(),
     )
     krylov_solver = ksp_scheme.make_solver(
-        mat_orig=block_linear_system, options={"gmres": {"ksp_type": "fgmres"}}
+        mat_orig=block_linear_system,
+        options={
+            "gmres": {"ksp_type": "fgmres"},
+            "delete_matrices": False,
+        },
     )
     # Check that the custom option applied.
     assert krylov_solver.ksp.type == "fgmres"


### PR DESCRIPTION
1. When the block matrix has been constructed and taken ownership of the global system matrix, the original system matrix is deleted.
2. When the underlying linear system of the block matrix has been represented in PETSc (by copying), the matrix of the block matrix (but not the index information) is deleted.
3. When the global matrix is assembled, we make sure that scipy does not create a view that has unnecessarily large memory footprint.