### PR TITLE
MAINT: Scipy matrix is deleted by default

### DIFF
--- a/src/pp_solvers/options_parsers.py
+++ b/src/pp_solvers/options_parsers.py
@@ -43,7 +43,7 @@ class PetscKSPScheme:
 
         # Construct a PETSc matrix from the scipy matrix.
         petsc_mat = csr_to_petsc(mat_orig.mat)
-        if options.get("delete_matrices", False):
+        if options.get("delete_matrices", True):
             del mat_orig.mat  # Delete the scipy matrix to save memory.
 
         # Clear the PETSc options from a previous solve.


### PR DESCRIPTION
After the PETSc representation of the matrix has been constructed

The default parameter was wrongly set to False